### PR TITLE
[BAU] remove unnecessary fund-store container from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,18 @@ services:
       - DATABASE_URL=postgresql://postgres:password@database:5432/data_store
     depends_on:
       - database
+  account-store:
+    build:
+      context: ../funding-service-design-account-store
+    command: bash -c "flask db upgrade && flask run -p 8080 -h 0.0.0.0"
+    environment:
+      - FLASK_ENV=development
+      - DATABASE_URL=postgresql://postgres:password@database:5432/account_store
+    volumes: [ '../funding-service-design-account-store:/app' ]
+    ports:
+      - 3003:8080
+    depends_on:
+      - database
   authenticator:
     build:
       context: ../funding-service-design-authenticator
@@ -20,19 +32,13 @@ services:
       - 4004:8080
       - 5684:5678
     depends_on:
-      - account-store
-      - fund-store
       - redis-data
+      - account-store
     environment:
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
-      - APPLICATION_STORE_API_HOST=http://application-store:8080  # not used
-      - FUND_STORE_API_HOST=http://fund-store:8080  # required
       - AUTHENTICATOR_HOST=http://localhost:4004
-      - NOTIFICATION_SERVICE_HOST=http://notification:8080  # not used
       - POST_AWARD_FRONTEND_HOST=http://localhost:4002
-      - APPLICANT_FRONTEND_HOST=http://localhost:3008
-      - ASSESSMENT_FRONTEND_HOST=http://localhost:3010
       #  Uncomment to test Azure AD locally once credentials are set in .env
 #      - AZURE_AD_CLIENT_ID=${AZURE_AD_CLIENT_ID:?err}
 #      - AZURE_AD_CLIENT_SECRET=${AZURE_AD_CLIENT_SECRET:?err}
@@ -67,30 +73,3 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=account_store,fund_store,data_store
     ports:
       - 5432:5432
-
-  # Needed because Authenticator is still tightly coupled with some parts of the pre-award applications
-  account-store:
-    build:
-      context: ../funding-service-design-account-store
-    command: bash -c "flask db upgrade && flask run -p 8080 -h 0.0.0.0"
-    environment:
-      - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/account_store
-    volumes: [ '../funding-service-design-account-store:/app' ]
-    ports:
-      - 3003:8080
-    depends_on:
-      - database
-  fund-store:
-    build:
-      context: ../funding-service-design-fund-store
-    command: bash -c "flask db upgrade && python -m debugpy --listen 0.0.0.0:5678 -m flask run -p 8080 -h 0.0.0.0"
-    environment:
-      - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/fund_store
-    ports:
-      - 3001:8080
-      - 5681:5678
-    depends_on:
-    - database
-    volumes: ['../funding-service-design-fund-store:/app']


### PR DESCRIPTION
### Change description
Removes fund-store from docker-compose. After testing, it was only required when FUND_STORE_API_HOST envar was set for Authenticator. This PR removes both that envar and the container from the docker-compose.

- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Set all repos to main, rebuild and run docker-compose, test authentication journey
