### PR TITLE
BAU: Fix postgres version to match AWS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     ports:
       - 6379:6379
   database:
-    image: postgres
+    image: postgres:14.4
     volumes:
       - ./docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
     restart: always


### PR DESCRIPTION
### Change description
Fix postgres version to match AWS environment. 
This should make testing locally behave as-per the deployed environments.

- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should run as before, only fetching versioned docker image (not latest)
