### PR TITLE
BAU: Fix Postgres multiple databases initialisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # On windows this file was converted to windows line endings on checkout, added attribute to ensure unix line endings
 # for running on docker
 localstack-script.sh text eol=lf
+docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     restart: always
     environment:
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=account_store,data_store
+      - POSTGRES_MULTIPLE_DATABASES=account_store,data_store,data_store_test
     ports:
       - 5432:5432
   submit:

--- a/docker-postgresql-multiple-databases/LICENSE
+++ b/docker-postgresql-multiple-databases/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Mart Sõmermaa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-postgresql-multiple-databases/README.md
+++ b/docker-postgresql-multiple-databases/README.md
@@ -1,0 +1,57 @@
+# Using multiple databases with the official PostgreSQL Docker image
+
+The [official recommendation](https://hub.docker.com/_/postgres/) for creating
+multiple databases is as follows:
+
+*If you would like to do additional initialization in an image derived from
+this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under
+`/docker-entrypoint-initdb.d` (creating the directory if necessary). After the
+entrypoint calls `initdb` to create the default `postgres` user and database,
+it will run any `*.sql` files and source any `*.sh` scripts found in that
+directory to do further initialization before starting the service.*
+
+This directory contains a script to create multiple databases using that
+mechanism.
+
+## Usage
+
+### By mounting a volume
+
+Clone the repository, mount its directory as a volume into
+`/docker-entrypoint-initdb.d` and declare database names separated by commas in
+`POSTGRES_MULTIPLE_DATABASES` environment variable as follows
+(`docker-compose` syntax):
+
+    myapp-postgresql:
+        image: postgres:9.6.2
+        volumes:
+            - ../docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES=db1,db2
+            - POSTGRES_USER=myapp
+            - POSTGRES_PASSWORD=
+
+### By building a custom image
+
+Clone the repository, build and push the image to your Docker repository,
+for example for Google Private Repository do the following:
+
+    docker build --tag=eu.gcr.io/your-project/postgres-multi-db .
+    gcloud docker -- push eu.gcr.io/your-project/postgres-multi-db
+
+You still need to pass the `POSTGRES_MULTIPLE_DATABASES` environment variable
+to the container:
+
+    myapp-postgresql:
+        image: eu.gcr.io/your-project/postgres-multi-db
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES=db1,db2
+            - POSTGRES_USER=myapp
+            - POSTGRES_PASSWORD=
+
+### Non-standard database names
+
+If you need to use non-standard database names (hyphens, uppercase letters etc), quote them in `POSTGRES_MULTIPLE_DATABASES`:
+
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES="test-db-1","test-db-2"

--- a/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
+++ b/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -u
+
+if [ -z "${POSTGRES_USER}" ]; then
+  POSTGRES_USER="postgres"
+fi
+
+function create_user_and_database() {
+	local database=$1
+	echo "  Creating user and database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	    CREATE USER $database;
+	    CREATE DATABASE $database;
+	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		create_user_and_database $db
+	done
+	echo "Multiple databases created"
+fi


### PR DESCRIPTION
### Change description
Previously the multiple databases function of the docker compose file never worked as it was missing the dependent scripts (used on pre-award)

- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Running 
`docker compose rm database` 
`docker compose up database`
you should see a script run which outputs `Multiple databases created`

Running 
`docker compose down`
`docker compose up`
should create an environment including databases