### PR TITLE
Reset directory back to starting dir when running reset-all-repos.sh

### DIFF
--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -36,18 +36,20 @@ fi
 if [ "$reset_to_main" = true ] ; then
     echo Resetting all repos to main
 
-    cd $workspace_dir
+    (
+      cd $workspace_dir
 
-    declare -a repos=("authenticator" "account-store" "post-award-data-store" "post-award-data-frontend", "post-award-submit")
+      declare -a repos=("authenticator" "account-store" "post-award-data-store" "post-award-data-frontend", "post-award-submit")
 
-    for repo in "${repos[@]}"
-    do
-    echo -------------------------------------------------------------------------
-    echo ========= Resetting "$repo" =======
-    cd $workspace_dir/$fsd-$repo
-    git status
-    git checkout main
-    git pull
-    echo -------------------------------------------------------------------------
-    done
+      for repo in "${repos[@]}"
+      do
+      echo -------------------------------------------------------------------------
+      echo ========= Resetting "$repo" =======
+      cd $workspace_dir/$fsd-$repo
+      git status
+      git checkout main
+      git pull
+      echo -------------------------------------------------------------------------
+      done
+    )
 fi


### PR DESCRIPTION

### Change description
Moved script to subshell, to avoid the annoying situation where your directory has changed after running this script from terminal


### How to test
Run the script, check if the dir is as expected (ie where you were before you executed it)
