### PR TITLE
FPASF-90: Add seed method to data-store command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     # https://github.com/communitiesuk/funding-service-design-post-award-data-store
     build:
       context: ../funding-service-design-post-award-data-store
-      args: 
+      args:
         REQUIREMENTS: requirements-dev.txt
-    command: bash -c "flask db upgrade && ${VSC_DEBUG:-flask run -p 8080 -h 0.0.0.0}"
+    command: bash -c "flask db upgrade && flask seed-ref && ${VSC_DEBUG:-flask run -p 8080 -h 0.0.0.0}"
     volumes: [ '../funding-service-design-post-award-data-store:/app' ]
     stdin_open: true
     tty: true
@@ -22,7 +22,7 @@ services:
       - AWS_ENDPOINT_OVERRIDE=http://localstack:4566/
       - AWS_S3_BUCKET_FAILED_FILES=data-store-failed-files-dev
       - AWS_S3_BUCKET_FIND_DATA_FILES=data-store-find-data
-#      - NOTIFY_FIND_API_KEY=${NOTIFY_FIND_API_KEY:?err}
+      #      - NOTIFY_FIND_API_KEY=${NOTIFY_FIND_API_KEY:?err}
       - FIND_SERVICE_BASE_URL=http://localhost:4002
     restart: unless-stopped
     depends_on:
@@ -59,17 +59,20 @@ services:
       - POST_AWARD_FRONTEND_HOST=http://localhost:4002
       - POST_AWARD_SUBMIT_HOST=http://localhost:4003
       #  Uncomment to test Azure AD locally once credentials are set in .env
-#      - AZURE_AD_CLIENT_ID=${AZURE_AD_CLIENT_ID:?err}
-#      - AZURE_AD_CLIENT_SECRET=${AZURE_AD_CLIENT_SECRET:?err}
-#      - AZURE_AD_TENANT_ID=${AZURE_AD_TENANT_ID:?err}
+      #      - AZURE_AD_CLIENT_ID=${AZURE_AD_CLIENT_ID:?err}
+      #      - AZURE_AD_CLIENT_SECRET=${AZURE_AD_CLIENT_SECRET:?err}
+      #      - AZURE_AD_TENANT_ID=${AZURE_AD_TENANT_ID:?err}
   frontend:
     # https://github.com/communitiesuk/funding-service-design-post-award-data-frontend
     build:
       context: ../funding-service-design-post-award-data-frontend
       dockerfile: Dockerfile
-      args: 
+      args:
         REQUIREMENTS: requirements-dev.txt
-    volumes: [ '../funding-service-design-post-award-data-frontend:/app' ]
+    volumes:
+      [
+        '../funding-service-design-post-award-data-frontend:/app'
+      ]
     command: bash -c "${VSC_DEBUG:-flask run -p 8080 -h 0.0.0.0}"
     depends_on:
       - data-store
@@ -123,8 +126,8 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559" # external services port range
     environment:
       - DEBUG=${DEBUG-}
       - DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
### Change description
Adds `flask seed-ref` command to `data-store` command to seed reference data on start-up now that older data migrations will be removed from data-store migration files and no longer seeded when the db migrations are run locally.

- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Drop all data in your local database, bring down the docker containers and then bring them back up. The `geospatial_dim` and `fund_dim` tables should be populated with reference data.