### PR TITLE
Add S3 bucket env var for file download files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
       - AWS_ENDPOINT_OVERRIDE=http://localstack:4566/
+      - AWS_S3_BUCKET_FIND_DATA_FILES=data-store-find-data
 #      - NOTIFY_FIND_API_KEY=${NOTIFY_FIND_API_KEY:?err}
       - FIND_SERVICE_BASE_URL=http://localhost:4002
       - REDIS_URL=redis://redis-data:6379


### PR DESCRIPTION
Celery needs to know, at the very least, which bucket find download files are stored in, because it interacts with that bucket. This was accidentally removed during PR review.