### PR TITLE
BAU: update postgres version to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,12 +60,13 @@ services:
     command: bash -c "flask db upgrade && flask run -p 8080 -h 0.0.0.0"
     environment:
       - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/account_store
+      - DATABASE_URL=postgresql://postgres:password@account-store-database:5432/account_store
     volumes: [ '../funding-service-design-account-store:/app' ]
     ports:
       - 3003:8080
     depends_on:
-      - database
+      account-store-database:
+        condition: service_healthy
   authenticator:
     # https://github.com/communitiesuk/funding-service-design-authenticator
     build:
@@ -95,14 +96,28 @@ services:
     image: redis
     ports:
       - 6379:6379
-  database:
+  account-store-database:
     image: postgres:14.4
+    restart: always
+    environment:
+      - POSTGRES_DB=account_store
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_MULTIPLE_DATABASES=account_store,data_store,data_store_test
+    ports:
+      - 5433:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  database:
+    image: postgres:16.2
     volumes:
       - ./docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
     restart: always
     environment:
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=account_store,data_store,data_store_test
+      - POSTGRES_MULTIPLE_DATABASES=data_store,data_store_test
     ports:
       - 5432:5432
   localstack:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,10 @@
+x-postgres-healthcheck: &postgres-healthcheck
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 services:
   data-store:
     # https://github.com/communitiesuk/funding-service-design-post-award-data-store
@@ -27,7 +34,8 @@ services:
       - REDIS_URL=redis://redis-data:6379/1
     restart: unless-stopped
     depends_on:
-      - database
+      database:
+        condition: service_healthy
   celery:
     build:
       context: ../funding-service-design-post-award-data-store
@@ -36,8 +44,10 @@ services:
     command: celery -A app.celery_app worker --loglevel INFO
     volumes: [ '../funding-service-design-post-award-data-store:/app' ]
     depends_on:
-      - database
-      - redis-data
+      redis-data:
+        condition: service_started
+      database:
+        condition: service_healthy
     env_file: .env
     environment:
       - FLASK_ENV=development
@@ -102,14 +112,9 @@ services:
     environment:
       - POSTGRES_DB=account_store
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=account_store,data_store,data_store_test
     ports:
       - 5433:5432
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+    <<: *postgres-healthcheck
   database:
     image: postgres:16.2
     volumes:
@@ -120,6 +125,7 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=data_store,data_store_test
     ports:
       - 5432:5432
+    <<: *postgres-healthcheck
   localstack:
     image: localstack/localstack
     ports:


### PR DESCRIPTION
### Change description
* Upgrade Postgres version to reflect running version on environments
* Split out separate database for account-store to reflect running version
* Add shared healthcheck fragment for postgres to prevent start-up race condition

Note, you will need to re-create your database instance as the data volume cannot move between versions.
Run `docker compose down database` and re-run to fix this.

- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Run `docker compose down database`
Run `docker compose up`
All services should start and connect to DBs.
